### PR TITLE
Intellisense: doc comments and inbox (server) terminology

### DIFF
--- a/Sources/Mailosaur/MailosaurClient.swift
+++ b/Sources/Mailosaur/MailosaurClient.swift
@@ -7,6 +7,11 @@
 
 import Foundation
 
+/// The Mailosaur client — the main entry point to the Mailosaur API. Construct an instance with
+/// a ``MailosaurConfig`` containing your API key (or set the `MAILOSAUR_API_KEY` environment
+/// variable and use the throwing convenience initializer), then use the operations namespaces
+/// (``messages``, ``servers``, ``files``, ``devices``, ``analysis``, ``previews``, ``usage``) to
+/// automate email and SMS testing.
 public class MailosaurClient {
     private let config: MailosaurConfig
     private let defaultBaseUrl = URL(string: "https://mailosaur.com/")!
@@ -70,32 +75,46 @@ public class MailosaurClient {
     
     struct None: Decodable { }
     
+    /// Operations for analyzing email content and deliverability, including spam scoring.
     public lazy var analysis: Analysis = {
         Analysis(client: self)
     } ()
+    /// Operations for managing virtual security devices and retrieving their one-time passwords.
     public lazy var devices: Devices = {
         Devices(client: self)
     } ()
+    /// Operations for downloading attachments, EML source, and email preview screenshots.
     public lazy var files: Files = {
         Files(client: self)
     } ()
+    /// Operations for finding, retrieving, creating, and managing email and SMS messages.
     public lazy var messages: Messages = {
         Messages(client: self)
     } ()
+    /// Operations for creating and managing your Mailosaur servers (virtual inboxes).
     public lazy var servers: Servers = {
         Servers(client: self)
     } ()
+    /// Operations for inspecting account usage limits and recent transactional usage.
     public lazy var usage: Usage = {
         Usage(client: self)
     } ()
+    /// Operations for discovering the email clients available for generating email previews.
     public lazy var previews: Previews = {
         Previews(client: self)
     } ()
-    
+
+    /// Creates an instance of the Mailosaur client using an explicit configuration.
+    ///
+    /// - Parameter config: The configuration containing the API key and, optionally, an override base URL.
     public init(config: MailosaurConfig) {
         self.config = config
     }
 
+    /// Creates an instance of the Mailosaur client using the `MAILOSAUR_API_KEY` environment variable.
+    ///
+    /// - Parameter baseUrl: Optionally overrides the base URL of the Mailosaur service.
+    /// - Throws: `MailosaurError.missingApiKey` if the `MAILOSAUR_API_KEY` environment variable is not set or is empty.
     public convenience init(baseUrl: URL? = nil) throws {
         guard let apiKey = ProcessInfo.processInfo.environment["MAILOSAUR_API_KEY"],
               !apiKey.isEmpty else {

--- a/Sources/Mailosaur/MailosaurClient.swift
+++ b/Sources/Mailosaur/MailosaurClient.swift
@@ -91,7 +91,7 @@ public class MailosaurClient {
     public lazy var messages: Messages = {
         Messages(client: self)
     } ()
-    /// Operations for creating and managing your Mailosaur servers (virtual inboxes).
+    /// Operations for creating and managing your Mailosaur inboxes (servers).
     public lazy var servers: Servers = {
         Servers(client: self)
     } ()

--- a/Sources/Mailosaur/Models/MessageModels.swift
+++ b/Sources/Mailosaur/Models/MessageModels.swift
@@ -31,7 +31,7 @@ public struct Message: Decodable {
     /// Gets or sets an array of attachment metadata for any attached files
     public let attachments: [MessageAttachment]
     public let metadata: MessageMetadata
-    /// Gets or sets identifier for the server in which the message is located
+    /// Gets or sets identifier for the inbox (server) in which the message is located
     public let server: String
 }
 
@@ -129,7 +129,7 @@ public struct MessageSummary: Decodable {
     public let subject: String
     /// Summary snippet taken from message body
     public let summary: String
-    /// Gets or sets identifier for the server in which the message is lcoated
+    /// Gets or sets identifier for the inbox (server) in which the message is lcoated
     public let server: String
     /// Number of message attachments
     public let attachments: Int?

--- a/Sources/Mailosaur/Models/ServersModels.swift
+++ b/Sources/Mailosaur/Models/ServersModels.swift
@@ -6,26 +6,26 @@
 //
 
 public struct Server: Codable {
-    /// Gets or sets unique identifier for the server. Used as username for
+    /// Gets or sets unique identifier for the inbox (server). Used as username for
     /// SMTP/POP3 authentication.
     public let id: String
-    /// Gets or sets a name used to identify the server.
+    /// Gets or sets a name used to identify the inbox (server).
     public let name: String
     /// Gets or sets users (excluding administrators) who have access to
-    /// the server.
+    /// the inbox (server) when access is restricted.
     public let users: [String]
-    /// Gets or sets the number of messages currently in the server.
+    /// Gets or sets the number of messages currently in the inbox (server).
     public let messages: Int
 }
 
 public struct ServerListResult: Decodable {
-    /// Gets or sets the individual servers forming the result. Servers are
+    /// Gets or sets the individual inboxes (servers) forming the result. Inboxes (servers) are
     /// returned sorted by creation date, with the most recently-created
-    /// server appearing first.
+    /// inbox (server) appearing first.
     public let items: [Server]
 }
 
 public struct ServerCreateOptions: Encodable {
-    /// Gets or sets a name used to identify the server.
+    /// Gets or sets a name used to identify the inbox (server).
     public let name: String
 }

--- a/Sources/Mailosaur/Operations/Analysis.swift
+++ b/Sources/Mailosaur/Operations/Analysis.swift
@@ -5,17 +5,20 @@
 //  Created by Mailosaur on 19.01.2023.
 //
 
+/// Operations for analyzing the content and deliverability of an email, including SpamAssassin
+/// scoring and per-provider deliverability reports. Accessed via `client.analysis`.
 public class Analysis {
     // Must be weak to prevent a retain cycle
     weak var client: MailosaurClient?
-    
+
     public init(client: MailosaurClient) {
         self.client = client
     }
-    
+
     /// Perform a spam analysis of an email.
     ///
     /// - Parameter email: The identifier of the message to be analyzed.
+    /// - Returns: A `Result` containing a ``SpamAnalysisResult`` with the spam score and filter results on success, or an `Error` on failure.
     public func spamResult(email: String) async -> Result<SpamAnalysisResult, Error> {
         guard let client = self.client else { return .failure(MailosaurError.clientUninitialized) }
         return await client.performRequest(path: "api/analysis/spam/\(email)")
@@ -24,6 +27,7 @@ public class Analysis {
     /// Perform a spam analysis of an email.
     ///
     /// - Parameter email: The identifier of the message to be analyzed.
+    /// - Returns: A ``SpamAnalysisResult`` containing the spam score and filter results.
     public func spam(email: String) async throws -> SpamAnalysisResult {
         let result = await self.spamResult(email: email)
         switch result {
@@ -37,6 +41,7 @@ public class Analysis {
     /// Perform a deliverability report of an email.
     ///
     /// - Parameter email: The identifier of the message to be analyzed.
+    /// - Returns: A `Result` containing a ``DeliverabilityReport`` for the email on success, or an `Error` on failure.
     public func deliverabilityResult(email: String) async -> Result<DeliverabilityReport, Error> {
         guard let client = self.client else { return .failure(MailosaurError.clientUninitialized) }
         return await client.performRequest(path: "api/analysis/deliverability/\(email)")
@@ -45,6 +50,7 @@ public class Analysis {
     /// Perform a deliverability report of an email.
     ///
     /// - Parameter email: The identifier of the message to be analyzed.
+    /// - Returns: A ``DeliverabilityReport`` for the email.
     public func deliverability(email: String) async throws -> DeliverabilityReport {
         let result = await self.deliverabilityResult(email: email)
         switch result {

--- a/Sources/Mailosaur/Operations/Devices.swift
+++ b/Sources/Mailosaur/Operations/Devices.swift
@@ -5,21 +5,28 @@
 //  Created by Mailosaur on 20.01.2023.
 //
 
+/// Operations for managing virtual security devices and retrieving their current one-time
+/// passwords (OTPs), used to automate testing of app-based multi-factor authentication.
+/// Accessed via `client.devices`.
 public class Devices {
     // Must be weak to prevent a retain cycle
     private weak var client: MailosaurClient?
-    
+
     public init(client: MailosaurClient) {
         self.client = client
     }
-    
+
     /// Returns a list of your virtual security devices.
+    ///
+    /// - Returns: A `Result` containing a ``DeviceListResult`` of your devices on success, or an `Error` on failure.
     public func listResult() async -> Result<DeviceListResult, Error> {
         guard let client = self.client else { return .failure(MailosaurError.clientUninitialized) }
         return await client.performRequest(path: "api/devices")
     }
     
     /// Returns a list of your virtual security devices.
+    ///
+    /// - Returns: A ``DeviceListResult`` containing your devices.
     public func list() async throws -> DeviceListResult {
         let result = await self.listResult()
         switch result {
@@ -33,6 +40,7 @@ public class Devices {
     /// Creates a new virtual security device.
     ///
     /// - Parameter options: Options used to create a new Mailosaur virtual security device.
+    /// - Returns: A `Result` containing the newly-created ``Device`` on success, or an `Error` on failure.
     public func createResult(options: DeviceCreateOptions) async -> Result<Device, Error> {
         guard let client = self.client else { return .failure(MailosaurError.clientUninitialized) }
         return await client.performRequest(path: "api/devices",
@@ -44,6 +52,7 @@ public class Devices {
     /// Creates a new virtual security device.
     ///
     /// - Parameter options: Options used to create a new Mailosaur virtual security device.
+    /// - Returns: The newly-created ``Device``.
     public func create(options: DeviceCreateOptions) async throws -> Device {
         let result = await self.createResult(options: options)
         switch result {
@@ -57,6 +66,7 @@ public class Devices {
     /// Retrieves the current one-time password for a saved device, or given base32-encoded shared secret.
     ///
     /// - Parameter query: Either the unique identifier of the device, or a base32-encoded shared secret.
+    /// - Returns: A `Result` containing an ``OtpResult`` with the current one-time password on success, or an `Error` on failure.
     public func otpResult(query: String) async -> Result<OtpResult, Error> {
         guard let client = self.client else { return .failure(MailosaurError.clientUninitialized) }
         if query.contains("-") {
@@ -68,6 +78,7 @@ public class Devices {
     /// Retrieves the current one-time password for a saved device, or given base32-encoded shared secret.
     ///
     /// - Parameter query: Either the unique identifier of the device, or a base32-encoded shared secret.
+    /// - Returns: An ``OtpResult`` containing the current one-time password.
     public func otp(query: String) async throws -> OtpResult {
         let result = await self.otpResult(query: query)
         switch result {
@@ -81,6 +92,7 @@ public class Devices {
     /// Permanently delete a virtual security device. This operation cannot be undone.
     ///
     /// - Parameter id: The unique identifier of the device.
+    /// - Returns: A `Result` that is successful once the device has been deleted, or an `Error` on failure.
     public func deleteResult(id: String) async -> Result<(), Error> {
         guard let client = self.client else { return .failure(MailosaurError.clientUninitialized) }
         let result: Result<MailosaurClient.None, Error> = await client.performRequest(path: "api/devices/\(id)", method: .delete)
@@ -90,6 +102,7 @@ public class Devices {
     /// Permanently delete a virtual security device. This operation cannot be undone.
     ///
     /// - Parameter id: The unique identifier of the device.
+    /// - Returns: Once the device has been deleted.
     public func delete(id: String) async throws {
         let result = await self.deleteResult(id: id)
         switch result {

--- a/Sources/Mailosaur/Operations/Files.swift
+++ b/Sources/Mailosaur/Operations/Files.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+/// Operations for downloading the raw content associated with a message — file attachments,
+/// the full EML source of an email, and rendered email previews. Accessed via `client.files`.
 public class Files {
     // Must be weak to prevent a retain cycle
     private weak var client: MailosaurClient?
@@ -18,6 +20,7 @@ public class Files {
     /// Downloads a single attachment.
     ///
     /// - Parameter id: The identifier for the required attachment.
+    /// - Returns: A `Result` containing the attachment's binary content as `Data` on success, or an `Error` on failure.
     public func getAttachmentResult(id: String) async -> Result<Data, Error> {
         guard let client = self.client else { return .failure(MailosaurError.clientUninitialized) }
         return await client.performRequest(path: "api/files/attachments/\(id)", requestType: .data)
@@ -26,6 +29,7 @@ public class Files {
     /// Downloads a single attachment.
     ///
     /// - Parameter id: The identifier for the required attachment.
+    /// - Returns: The attachment's binary content as `Data`.
     public func getAttachment(id: String) async throws -> Data {
         let result = await self.getAttachmentResult(id: id)
         switch result {
@@ -36,17 +40,19 @@ public class Files {
         }
     }
     
-    /// ownloads an EML file representing the specified email.
+    /// Downloads an EML file representing the specified email.
     ///
     /// - Parameter id: The identifier for the required message.
+    /// - Returns: A `Result` containing the raw EML content of the email as `Data` on success, or an `Error` on failure.
     public func getEmailResult(id: String) async -> Result<Data, Error> {
         guard let client = self.client else { return .failure(MailosaurError.clientUninitialized) }
         return await client.performRequest(path: "api/files/email/\(id)", requestType: .data)
     }
     
-    /// ownloads an EML file representing the specified email.
+    /// Downloads an EML file representing the specified email.
     ///
     /// - Parameter id: The identifier for the required message.
+    /// - Returns: The raw EML content of the email as `Data`.
     public func getEmail(id: String) async throws -> Data {
         let result = await self.getEmailResult(id: id)
         switch result {
@@ -60,7 +66,8 @@ public class Files {
     /// Downloads a screenshot of your email rendered in a real email client. Simply supply
     /// the unique identifier for the required preview.
     ///
-    /// - Parameter id: The identifier of the preview to be downloaded.
+    /// - Parameter id: The identifier of the email preview to be downloaded.
+    /// - Returns: A `Result` containing the preview screenshot image as `Data` on success, or an `Error` on failure (including a `MailosaurError.generic` if the preview is not generated within the time limit).
     public func getPreviewResult(id: String) async -> Result<Data, Error> {
         guard let client = self.client else { return .failure(MailosaurError.clientUninitialized) }
         
@@ -113,7 +120,9 @@ public class Files {
     /// Downloads a screenshot of your email rendered in a real email client. Simply supply
     /// the unique identifier for the required preview.
     ///
-    /// - Parameter id: The identifier of the preview to be downloaded.
+    /// - Parameter id: The identifier of the email preview to be downloaded.
+    /// - Returns: The preview screenshot image as `Data`.
+    /// - Throws: `MailosaurError.generic` if the preview is not generated within the time limit (mirrors the API `preview_timeout` condition).
     public func getPreview(id: String) async throws -> Data {
         let result = await self.getPreviewResult(id: id)
         switch result {

--- a/Sources/Mailosaur/Operations/Messages.swift
+++ b/Sources/Mailosaur/Operations/Messages.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Operations for finding, retrieving, creating, forwarding, replying to, and deleting the
-/// email and SMS messages received by your Mailosaur servers. Accessed via `client.messages`.
+/// email and SMS messages received by your Mailosaur inboxes (servers). Accessed via `client.messages`.
 public class Messages {
     // Must be weak to prevent a retain cycle
     private weak var client: MailosaurClient?
@@ -21,11 +21,11 @@ public class Messages {
     ///
     ///  - Note: This is the most efficient method of looking up a message, therefore we recommend using it wherever possible.
     ///  - Parameters:
-    ///    - server: The unique identifier of the containing server.
+    ///    - server: The unique identifier of the containing inbox (server).
     ///    - criteria: The criteria with which to find messages during a search.
     ///    - timeout: The maximum time, in milliseconds, to wait for a matching message to arrive.
     ///    - receivedAfter: Limits results to messages received after this date. Defaults to one hour ago.
-    ///  - Returns: A `Result` containing the first ``Message`` matching the criteria on success, or an `Error` on failure (for example a `MailosaurError.generic` for an invalid server ID, or when the search times out).
+    ///  - Returns: A `Result` containing the first ``Message`` matching the criteria on success, or an `Error` on failure (for example a `MailosaurError.generic` for an invalid inbox (server) ID, or when the search times out).
     public func getResult(server: String, criteria: MessageSearchCriteria? = nil, timeout: Int = 1000, receivedAfter: Date? = nil) async -> Result<Message, Error> {
         let receivedAfterFinal = receivedAfter ?? Calendar.current.date(byAdding: .hour, value: -1, to: Date.now)
         let criteriaFinal = criteria ?? MessageSearchCriteria()
@@ -45,12 +45,12 @@ public class Messages {
     ///
     ///  - Note: This is the most efficient method of looking up a message, therefore we recommend using it wherever possible.
     ///  - Parameters:
-    ///    - server: The unique identifier of the containing server.
+    ///    - server: The unique identifier of the containing inbox (server).
     ///    - criteria: The criteria with which to find messages during a search.
     ///    - timeout: The maximum time, in milliseconds, to wait for a matching message to arrive.
     ///    - receivedAfter: Limits results to messages received after this date. Defaults to one hour ago.
     ///  - Returns: The first ``Message`` matching the criteria.
-    ///  - Throws: `MailosaurError.generic` if an invalid server ID is supplied, or if no matching message arrives before the timeout elapses (mirrors the API `search_timeout` condition).
+    ///  - Throws: `MailosaurError.generic` if an invalid inbox (server) ID is supplied, or if no matching message arrives before the timeout elapses (mirrors the API `search_timeout` condition).
     public func get(server: String, criteria: MessageSearchCriteria? = nil, timeout: Int = 1000, receivedAfter: Date? = nil) async throws -> Message {
         let result = await self.getResult(server: server, criteria: criteria, timeout: timeout, receivedAfter: receivedAfter)
         switch result {
@@ -113,7 +113,7 @@ public class Messages {
     /// Returns a list of your messages in summary form. The summaries are returned sorted by received date, with the most recently-received messages appearing first.
     ///
     /// - Parameters:
-    ///   - server: The unique identifier of the required server.
+    ///   - server: The unique identifier of the required inbox (server).
     ///   - page: Used in conjunction with `itemsPerPage` to support pagination.
     ///   - itemsPerPage: A limit on the number of results to be returned per page.
     ///   - receivedAfter: Limits results to messages received after this date.
@@ -135,7 +135,7 @@ public class Messages {
     /// Returns a list of your messages in summary form. The summaries are returned sorted by received date, with the most recently-received messages appearing first.
     ///
     /// - Parameters:
-    ///   - server: The unique identifier of the required server.
+    ///   - server: The unique identifier of the required inbox (server).
     ///   - page: Used in conjunction with `itemsPerPage` to support pagination.
     ///   - itemsPerPage: A limit on the number of results to be returned per page.
     ///   - receivedAfter: Limits results to messages received after this date.
@@ -151,10 +151,10 @@ public class Messages {
         }
     }
     
-    /// Permanently delete all messages within a server. This operation cannot be undone.
+    /// Permanently delete all messages within an inbox (server). This operation cannot be undone.
     ///
-    /// - Parameter server: The unique identifier of the required server.
-    /// - Returns: A `Result` that is successful once all messages within the server have been deleted, or an `Error` on failure.
+    /// - Parameter server: The unique identifier of the required inbox (server).
+    /// - Returns: A `Result` that is successful once all messages within the inbox (server) have been deleted, or an `Error` on failure.
     public func deleteAllResult(server: String) async -> Result<(), Error> {
         guard let client = self.client else { return .failure(MailosaurError.clientUninitialized) }
         var queryItems = [URLQueryItem] ()
@@ -164,10 +164,10 @@ public class Messages {
         return result.map { _ in () }
     }
     
-    /// Permanently delete all messages within a server. This operation cannot be undone.
+    /// Permanently delete all messages within an inbox (server). This operation cannot be undone.
     ///
-    /// - Parameter server: The unique identifier of the required server.
-    /// - Returns: Once all messages within the server have been deleted.
+    /// - Parameter server: The unique identifier of the required inbox (server).
+    /// - Returns: Once all messages within the inbox (server) have been deleted.
     public func deleteAll(server: String) async throws {
         let result = await self.deleteAllResult(server: server)
         switch result {
@@ -182,7 +182,7 @@ public class Messages {
     /// The messages are returned sorted by received date, with the most recently-received messages appearing first.
     ///
     ///  - Parameters:
-    ///    - server: The unique identifier of the server to search.
+    ///    - server: The unique identifier of the inbox (server) to search.
     ///    - criteria: The criteria with which to find messages during a search.
     ///    - page: Used in conjunction with `itemsPerPage` to support pagination.
     ///    - itemsPerPage: A limit on the number of results to be returned per page.
@@ -237,7 +237,7 @@ public class Messages {
     /// The messages are returned sorted by received date, with the most recently-received messages appearing first.
     ///
     ///  - Parameters:
-    ///    - server: The unique identifier of the server to search.
+    ///    - server: The unique identifier of the inbox (server) to search.
     ///    - criteria: The criteria with which to find messages during a search.
     ///    - page: Used in conjunction with `itemsPerPage` to support pagination.
     ///    - itemsPerPage: A limit on the number of results to be returned per page.
@@ -261,7 +261,7 @@ public class Messages {
     /// in scenarios where you want an email to trigger a workflow in your product.
     ///
     ///  - Parameters:
-    ///    - server: The unique identifier of the required server.
+    ///    - server: The unique identifier of the required inbox (server).
     ///    - messageCreateOptions: Options to use when creating a new message.
     ///  - Returns: A `Result` containing the newly-created ``Message`` on success, or an `Error` on failure.
     public func createResult(server: String, messageCreateOptions: MessageCreateOptions) async -> Result<Message, Error> {
@@ -276,7 +276,7 @@ public class Messages {
     /// in scenarios where you want an email to trigger a workflow in your product.
     ///
     ///  - Parameters:
-    ///    - server: The unique identifier of the required server.
+    ///    - server: The unique identifier of the required inbox (server).
     ///    - messageCreateOptions: Options to use when creating a new message.
     ///  - Returns: The newly-created ``Message``.
     public func create(server: String, messageCreateOptions: MessageCreateOptions) async throws -> Message {

--- a/Sources/Mailosaur/Operations/Messages.swift
+++ b/Sources/Mailosaur/Operations/Messages.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+/// Operations for finding, retrieving, creating, forwarding, replying to, and deleting the
+/// email and SMS messages received by your Mailosaur servers. Accessed via `client.messages`.
 public class Messages {
     // Must be weak to prevent a retain cycle
     private weak var client: MailosaurClient?
@@ -15,11 +17,15 @@ public class Messages {
         self.client = client
     }
     
-    /// Waits for a message to be found. Returns as soon as a message matching the specified search criteria is found.
+    /// Waits for a message to be found, returning as soon as a message matching the specified search criteria is found.
     ///
     ///  - Note: This is the most efficient method of looking up a message, therefore we recommend using it wherever possible.
-    ///  - Parameter server: The unique identifier of the containing server.
-    ///  - Parameter criteria: The criteria with which to find messages during a search.
+    ///  - Parameters:
+    ///    - server: The unique identifier of the containing server.
+    ///    - criteria: The criteria with which to find messages during a search.
+    ///    - timeout: The maximum time, in milliseconds, to wait for a matching message to arrive.
+    ///    - receivedAfter: Limits results to messages received after this date. Defaults to one hour ago.
+    ///  - Returns: A `Result` containing the first ``Message`` matching the criteria on success, or an `Error` on failure (for example a `MailosaurError.generic` for an invalid server ID, or when the search times out).
     public func getResult(server: String, criteria: MessageSearchCriteria? = nil, timeout: Int = 1000, receivedAfter: Date? = nil) async -> Result<Message, Error> {
         let receivedAfterFinal = receivedAfter ?? Calendar.current.date(byAdding: .hour, value: -1, to: Date.now)
         let criteriaFinal = criteria ?? MessageSearchCriteria()
@@ -35,11 +41,16 @@ public class Messages {
         }
     }
     
-    /// Waits for a message to be found. Returns as soon as a message matching the specified search criteria is found.
+    /// Waits for a message to be found, returning as soon as a message matching the specified search criteria is found.
     ///
     ///  - Note: This is the most efficient method of looking up a message, therefore we recommend using it wherever possible.
-    ///  - Parameter server: The unique identifier of the containing server.
-    ///  - Parameter criteria: The criteria with which to find messages during a search.
+    ///  - Parameters:
+    ///    - server: The unique identifier of the containing server.
+    ///    - criteria: The criteria with which to find messages during a search.
+    ///    - timeout: The maximum time, in milliseconds, to wait for a matching message to arrive.
+    ///    - receivedAfter: Limits results to messages received after this date. Defaults to one hour ago.
+    ///  - Returns: The first ``Message`` matching the criteria.
+    ///  - Throws: `MailosaurError.generic` if an invalid server ID is supplied, or if no matching message arrives before the timeout elapses (mirrors the API `search_timeout` condition).
     public func get(server: String, criteria: MessageSearchCriteria? = nil, timeout: Int = 1000, receivedAfter: Date? = nil) async throws -> Message {
         let result = await self.getResult(server: server, criteria: criteria, timeout: timeout, receivedAfter: receivedAfter)
         switch result {
@@ -54,6 +65,7 @@ public class Messages {
     /// search in order to get the unique identifier for the required message.
     ///
     ///  - Parameter id: The unique identifier of the message to be retrieved.
+    ///  - Returns: A `Result` containing the full ``Message`` on success, or an `Error` on failure.
     public func getByIdResult(id: String) async -> Result<Message, Error> {
         guard let client = self.client else { return .failure(MailosaurError.clientUninitialized) }
         return await client.performRequest(path: "api/messages/\(id)")
@@ -63,6 +75,7 @@ public class Messages {
     /// search in order to get the unique identifier for the required message.
     ///
     ///  - Parameter id: The unique identifier of the message to be retrieved.
+    ///  - Returns: The full ``Message``.
     public func getById(id: String) async throws -> Message {
         let result = await self.getByIdResult(id: id)
         switch result {
@@ -76,6 +89,7 @@ public class Messages {
     /// Permanently deletes a message. Also deletes any attachments related to the message. This operation cannot be undone.
     ///
     /// - Parameter id: The identifier for the message.
+    /// - Returns: A `Result` that is successful once the message has been deleted, or an `Error` on failure.
     public func deleteResult(id: String) async -> Result<(), Error> {
         guard let client = self.client else { return .failure(MailosaurError.clientUninitialized) }
         let result: Result<MailosaurClient.None, Error> = await client.performRequest(path: "api/messages/\(id)", method: .delete)
@@ -85,6 +99,7 @@ public class Messages {
     /// Permanently deletes a message. Also deletes any attachments related to the message. This operation cannot be undone.
     ///
     /// - Parameter id: The identifier for the message.
+    /// - Returns: Once the message has been deleted.
     public func delete(id: String) async throws {
         let result = await self.deleteResult(id: id)
         switch result {
@@ -97,7 +112,13 @@ public class Messages {
     
     /// Returns a list of your messages in summary form. The summaries are returned sorted by received date, with the most recently-received messages appearing first.
     ///
-    /// - Parameter server: The unique identifier of the required server.
+    /// - Parameters:
+    ///   - server: The unique identifier of the required server.
+    ///   - page: Used in conjunction with `itemsPerPage` to support pagination.
+    ///   - itemsPerPage: A limit on the number of results to be returned per page.
+    ///   - receivedAfter: Limits results to messages received after this date.
+    ///   - dir: Optionally sets the direction of message sorting, either `asc` or `desc`.
+    /// - Returns: A `Result` containing a ``MessageListResult`` of message summaries on success, or an `Error` on failure.
     public func listResult(server: String, page: Int? = nil, itemsPerPage: Int? = nil, receivedAfter: Date? = nil, dir: String? = nil) async -> Result<MessageListResult, Error> {
         guard let client = self.client else { return .failure(MailosaurError.clientUninitialized) }
         var queryItems = [URLQueryItem] ()
@@ -113,7 +134,13 @@ public class Messages {
     
     /// Returns a list of your messages in summary form. The summaries are returned sorted by received date, with the most recently-received messages appearing first.
     ///
-    /// - Parameter server: The unique identifier of the required server.
+    /// - Parameters:
+    ///   - server: The unique identifier of the required server.
+    ///   - page: Used in conjunction with `itemsPerPage` to support pagination.
+    ///   - itemsPerPage: A limit on the number of results to be returned per page.
+    ///   - receivedAfter: Limits results to messages received after this date.
+    ///   - dir: Optionally sets the direction of message sorting, either `asc` or `desc`.
+    /// - Returns: A ``MessageListResult`` containing the message summaries.
     public func list(server: String, page: Int? = nil, itemsPerPage: Int? = nil, receivedAfter: Date? = nil, dir: String? = nil) async throws -> MessageListResult {
         let result = await self.listResult(server: server, page: page, itemsPerPage: itemsPerPage, receivedAfter: receivedAfter, dir: dir)
         switch result {
@@ -124,9 +151,10 @@ public class Messages {
         }
     }
     
-    /// Permenantly delete all messages within a server.
+    /// Permanently delete all messages within a server. This operation cannot be undone.
     ///
     /// - Parameter server: The unique identifier of the required server.
+    /// - Returns: A `Result` that is successful once all messages within the server have been deleted, or an `Error` on failure.
     public func deleteAllResult(server: String) async -> Result<(), Error> {
         guard let client = self.client else { return .failure(MailosaurError.clientUninitialized) }
         var queryItems = [URLQueryItem] ()
@@ -136,9 +164,10 @@ public class Messages {
         return result.map { _ in () }
     }
     
-    /// Permenantly delete all messages within a server.
+    /// Permanently delete all messages within a server. This operation cannot be undone.
     ///
     /// - Parameter server: The unique identifier of the required server.
+    /// - Returns: Once all messages within the server have been deleted.
     public func deleteAll(server: String) async throws {
         let result = await self.deleteAllResult(server: server)
         switch result {
@@ -152,8 +181,16 @@ public class Messages {
     /// Returns a list of messages matching the specified search criteria, in summary form.
     /// The messages are returned sorted by received date, with the most recently-received messages appearing first.
     ///
-    ///  - Parameter server: The unique identifier of the containing server.
-    ///  - Parameter criteria: The criteria with which to find messages during a search.
+    ///  - Parameters:
+    ///    - server: The unique identifier of the server to search.
+    ///    - criteria: The criteria with which to find messages during a search.
+    ///    - page: Used in conjunction with `itemsPerPage` to support pagination.
+    ///    - itemsPerPage: A limit on the number of results to be returned per page.
+    ///    - timeout: The maximum time, in milliseconds, to wait for a matching message before giving up.
+    ///    - receivedAfter: Limits results to messages received after this date.
+    ///    - errorOnTimeout: When `true` (the default), a timeout with no results produces a failure; when `false`, an empty result is returned instead.
+    ///    - dir: Optionally sets the direction of message sorting, either `asc` or `desc`.
+    ///  - Returns: A `Result` containing a ``MessageListResult`` of matching message summaries on success, or an `Error` on failure (including a `MailosaurError.generic` when the search times out and `errorOnTimeout` is `true`).
     public func searchResult(server: String, criteria: MessageSearchCriteria, page: Int? = nil, itemsPerPage: Int? = nil, timeout: Int? = 0, receivedAfter: Date? = nil, errorOnTimeout: Bool = true, dir: String? = nil) async -> Result<MessageListResult, Error> {
         guard let client = self.client else { return .failure(MailosaurError.clientUninitialized) }
         var queryItems = [URLQueryItem] ()
@@ -199,8 +236,17 @@ public class Messages {
     /// Returns a list of messages matching the specified search criteria, in summary form.
     /// The messages are returned sorted by received date, with the most recently-received messages appearing first.
     ///
-    ///  - Parameter server: The unique identifier of the containing server.
-    ///  - Parameter criteria: The criteria with which to find messages during a search.
+    ///  - Parameters:
+    ///    - server: The unique identifier of the server to search.
+    ///    - criteria: The criteria with which to find messages during a search.
+    ///    - page: Used in conjunction with `itemsPerPage` to support pagination.
+    ///    - itemsPerPage: A limit on the number of results to be returned per page.
+    ///    - timeout: The maximum time, in milliseconds, to wait for a matching message before giving up.
+    ///    - receivedAfter: Limits results to messages received after this date.
+    ///    - errorOnTimeout: When `true` (the default), a timeout with no results throws; when `false`, an empty result is returned instead.
+    ///    - dir: Optionally sets the direction of message sorting, either `asc` or `desc`.
+    ///  - Returns: A ``MessageListResult`` containing the matching message summaries.
+    ///  - Throws: `MailosaurError.generic` if no matching message is found before the timeout elapses, unless `errorOnTimeout` is set to `false` (mirrors the API `search_timeout` condition).
     public func search(server: String, criteria: MessageSearchCriteria, page: Int? = nil, itemsPerPage: Int? = nil, timeout: Int? = 0, receivedAfter: Date? = nil, errorOnTimeout: Bool = true, dir: String? = nil) async throws -> MessageListResult {
         let result = await self.searchResult(server: server, criteria: criteria, page: page, itemsPerPage: itemsPerPage, timeout: timeout, receivedAfter: receivedAfter, errorOnTimeout: errorOnTimeout, dir: dir)
         switch result {
@@ -214,8 +260,10 @@ public class Messages {
     /// Creates a new message that can be sent to a verified email address. This is useful
     /// in scenarios where you want an email to trigger a workflow in your product.
     ///
-    ///  - Parameter server: The unique identifier of the required server.
-    ///  - Parameter messageCreateOptions: Options to use when creating a new message.
+    ///  - Parameters:
+    ///    - server: The unique identifier of the required server.
+    ///    - messageCreateOptions: Options to use when creating a new message.
+    ///  - Returns: A `Result` containing the newly-created ``Message`` on success, or an `Error` on failure.
     public func createResult(server: String, messageCreateOptions: MessageCreateOptions) async -> Result<Message, Error> {
         guard let client = self.client else { return .failure(MailosaurError.clientUninitialized) }
         var queryItems = [URLQueryItem] ()
@@ -224,8 +272,13 @@ public class Messages {
         return await client.performRequest(path: "api/messages", method: .post, query: queryItems, params: messageCreateOptions)
     }
     
-    ///  - Parameter server: The unique identifier of the required server.
-    ///  - Parameter messageCreateOptions: Options to use when creating a new message.
+    /// Creates a new message that can be sent to a verified email address. This is useful
+    /// in scenarios where you want an email to trigger a workflow in your product.
+    ///
+    ///  - Parameters:
+    ///    - server: The unique identifier of the required server.
+    ///    - messageCreateOptions: Options to use when creating a new message.
+    ///  - Returns: The newly-created ``Message``.
     public func create(server: String, messageCreateOptions: MessageCreateOptions) async throws -> Message {
         let result = await self.createResult(server: server, messageCreateOptions: messageCreateOptions)
         switch result {
@@ -236,21 +289,23 @@ public class Messages {
         }
     }
     
-    /// Creates a new message that can be sent to a verified email address. This is useful
-    /// in scenarios where you want an email to trigger a workflow in your product.
+    /// Forwards the specified message to a verified email address. This is useful for simulating a user forwarding one of your email messages.
     ///
-    ///  - Parameter server: The unique identifier of the message to be forwarded.
-    ///  - Parameter messageForwardOptions: Options to use when forwarding a message.
+    ///  - Parameters:
+    ///    - id: The unique identifier of the message to be forwarded.
+    ///    - messageForwardOptions: Options to use when forwarding a message.
+    ///  - Returns: A `Result` containing the forwarded ``Message`` on success, or an `Error` on failure.
     public func forwardResult(id: String, messageForwardOptions: MessageForwardOptions) async -> Result<Message, Error> {
         guard let client = self.client else { return .failure(MailosaurError.clientUninitialized) }
         return await client.performRequest(path: "api/messages/\(id)/forward", method: .post, params: messageForwardOptions)
     }
     
-    /// Creates a new message that can be sent to a verified email address. This is useful
-    /// in scenarios where you want an email to trigger a workflow in your product.
+    /// Forwards the specified message to a verified email address. This is useful for simulating a user forwarding one of your email messages.
     ///
-    ///  - Parameter server: The unique identifier of the message to be forwarded.
-    ///  - Parameter messageForwardOptions: Options to use when forwarding a message.
+    ///  - Parameters:
+    ///    - id: The unique identifier of the message to be forwarded.
+    ///    - messageForwardOptions: Options to use when forwarding a message.
+    ///  - Returns: The forwarded ``Message``.
     public func forward(id: String, messageForwardOptions: MessageForwardOptions) async throws -> Message {
         let result = await self.forwardResult(id: id, messageForwardOptions: messageForwardOptions)
         switch result {
@@ -263,8 +318,10 @@ public class Messages {
     
     /// Sends a reply to the specified message. This is useful for when simulating a user replying to one of your email or SMS messages.
     ///
-    ///  - Parameter id: The unique identifier of the message to be forwarded.
-    ///  - Parameter messageReplyOptions: Options to use when replying to a message.
+    ///  - Parameters:
+    ///    - id: The unique identifier of the message to be replied to.
+    ///    - messageReplyOptions: Options to use when replying to a message.
+    ///  - Returns: A `Result` containing the reply ``Message`` on success, or an `Error` on failure.
     public func replyResult(id: String, messageReplyOptions: MessageReplyOptions) async -> Result<Message, Error> {
         guard let client = self.client else { return .failure(MailosaurError.clientUninitialized) }
         return await client.performRequest(path: "api/messages/\(id)/reply", method: .post, params: messageReplyOptions)
@@ -272,8 +329,10 @@ public class Messages {
     
     /// Sends a reply to the specified message. This is useful for when simulating a user replying to one of your email or SMS messages.
     ///
-    ///  - Parameter id: The unique identifier of the message to be forwarded.
-    ///  - Parameter messageReplyOptions: Options to use when replying to a message.
+    ///  - Parameters:
+    ///    - id: The unique identifier of the message to be replied to.
+    ///    - messageReplyOptions: Options to use when replying to a message.
+    ///  - Returns: The reply ``Message``.
     public func reply(id: String, messageReplyOptions: MessageReplyOptions) async throws -> Message {
         let result = await self.replyResult(id: id, messageReplyOptions: messageReplyOptions)
         switch result {
@@ -286,8 +345,10 @@ public class Messages {
     
     /// Generates screenshots of an email rendered in the specified email clients.
     ///
-    ///  - Parameter id: The identifier of the email to preview.
-    ///  - Parameter options: The options with which to generate previews.
+    ///  - Parameters:
+    ///    - id: The identifier of the email to preview.
+    ///    - options: The options with which to generate previews.
+    ///  - Returns: A `Result` containing a ``PreviewListResult`` of the generated previews on success, or an `Error` on failure.
     public func generatePreviewsResult(id: String, options: PreviewRequestOptions) async -> Result<PreviewListResult, Error> {
         guard let client = self.client else { return .failure(MailosaurError.clientUninitialized) }
         return await client.performRequest(path: "api/messages/\(id)/screenshots", method: .post, params: options)
@@ -295,8 +356,10 @@ public class Messages {
     
     /// Generates screenshots of an email rendered in the specified email clients.
     ///
-    ///  - Parameter id: The identifier of the email to preview.
-    ///  - Parameter options: The options with which to generate previews.
+    ///  - Parameters:
+    ///    - id: The identifier of the email to preview.
+    ///    - options: The options with which to generate previews.
+    ///  - Returns: A ``PreviewListResult`` containing the generated previews.
     public func generatePreviews(id: String, options: PreviewRequestOptions) async throws -> PreviewListResult {
         let result = await self.generatePreviewsResult(id: id, options: options)
         switch result {

--- a/Sources/Mailosaur/Operations/Previews.swift
+++ b/Sources/Mailosaur/Operations/Previews.swift
@@ -7,21 +7,27 @@
 
 import Foundation
 
+/// Operations for discovering the email clients available for generating email previews
+/// (screenshots of an email rendered in real clients). Accessed via `client.previews`.
 public class Previews {
     // Must be weak to prevent a retain cycle
     private weak var client: MailosaurClient?
-    
+
     public init(client: MailosaurClient) {
         self.client = client
     }
-    
+
     /// Returns the list of all email clients that can be used to generate email previews.
+    ///
+    /// - Returns: A `Result` containing an ``EmailClientListResult`` of available email clients on success, or an `Error` on failure.
     public func listEmailClientsResult() async -> Result<EmailClientListResult, Error> {
         guard let client = self.client else { return .failure(MailosaurError.clientUninitialized) }
         return await client.performRequest(path: "api/screenshots/clients")
     }
     
     /// Returns the list of all email clients that can be used to generate email previews.
+    ///
+    /// - Returns: An ``EmailClientListResult`` of available email clients.
     public func listEmailClients() async throws -> EmailClientListResult {
         let result = await self.listEmailClientsResult()
         switch result {

--- a/Sources/Mailosaur/Operations/Servers.swift
+++ b/Sources/Mailosaur/Operations/Servers.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-/// Operations for creating and managing your Mailosaur servers — the virtual inboxes that
+/// Operations for creating and managing your Mailosaur inboxes (servers) — they
 /// group your tests together, each with its own domain and SMTP/POP3/IMAP credentials.
 /// Accessed via `client.servers`.
 public class Servers {
@@ -18,17 +18,17 @@ public class Servers {
         self.client = client
     }
     
-    /// Returns a list of your virtual servers. Servers are returned sorted in alphabetical order.
+    /// Returns a list of your inboxes (servers). Inboxes (servers) are returned sorted in alphabetical order.
     ///
-    /// - Returns: A `Result` containing a ``ServerListResult`` of your servers on success, or an `Error` on failure.
+    /// - Returns: A `Result` containing a ``ServerListResult`` of your inboxes (servers) on success, or an `Error` on failure.
     public func listResult() async -> Result<ServerListResult, Error> {
         guard let client = self.client else { return .failure(MailosaurError.clientUninitialized) }
         return await client.performRequest(path: "api/servers")
     }
     
-    /// Returns a list of your virtual servers. Servers are returned sorted in alphabetical order.
+    /// Returns a list of your inboxes (servers). Inboxes (servers) are returned sorted in alphabetical order.
     ///
-    /// - Returns: A ``ServerListResult`` containing your servers.
+    /// - Returns: A ``ServerListResult`` containing your inboxes (servers).
     public func list() async throws -> ServerListResult {
         let result = await self.listResult()
         switch result {
@@ -39,18 +39,18 @@ public class Servers {
         }
     }
     
-    /// Creates a new virtual server.
+    /// Creates a new inbox (server).
     ///
-    ///  - Parameter options: Options used to create a new Mailosaur server.
+    ///  - Parameter options: Options used to create a new Mailosaur inbox (server).
     ///  - Returns: A `Result` containing the newly-created ``Server`` on success, or an `Error` on failure.
     public func createResult(options: ServerCreateOptions) async -> Result<Server, Error> {
         guard let client = self.client else { return .failure(MailosaurError.clientUninitialized) }
         return await client.performRequest(path: "api/servers", method: .post, params: options)
     }
     
-    /// Creates a new virtual server.
+    /// Creates a new inbox (server).
     ///
-    ///  - Parameter options: Options used to create a new Mailosaur server.
+    ///  - Parameter options: Options used to create a new Mailosaur inbox (server).
     ///  - Returns: The newly-created ``Server``.
     public func create(options: ServerCreateOptions) async throws -> Server {
         let result = await self.createResult(options: options)
@@ -62,18 +62,18 @@ public class Servers {
         }
     }
     
-    /// Retrieves the detail for a single server.
+    /// Retrieves the detail for a single inbox (server).
     ///
-    ///  - Parameter id: The unique identifier of the server.
+    ///  - Parameter id: The unique identifier of the inbox (server).
     ///  - Returns: A `Result` containing the ``Server`` on success, or an `Error` on failure.
     public func getResult(id: String) async -> Result<Server, Error> {
         guard let client = self.client else { return .failure(MailosaurError.clientUninitialized) }
         return await client.performRequest(path: "api/servers/\(id)")
     }
     
-    /// Retrieves the detail for a single server.
+    /// Retrieves the detail for a single inbox (server).
     ///
-    ///  - Parameter id: The unique identifier of the server.
+    ///  - Parameter id: The unique identifier of the inbox (server).
     ///  - Returns: The ``Server``.
     public func get(id: String) async throws -> Server {
         let result = await self.getResult(id: id)
@@ -85,22 +85,22 @@ public class Servers {
         }
     }
     
-    /// Updates the attributes of a server.
+    /// Updates the attributes of an inbox (server).
     ///
     ///  - Parameters:
-    ///    - id: The unique identifier of the server.
-    ///    - server: The updated server.
+    ///    - id: The unique identifier of the inbox (server).
+    ///    - server: The updated inbox (server).
     ///  - Returns: A `Result` containing the updated ``Server`` on success, or an `Error` on failure.
     public func updateResult(id: String, server: Server) async -> Result<Server, Error> {
         guard let client = self.client else { return .failure(MailosaurError.clientUninitialized) }
         return await client.performRequest(path: "api/servers/\(id)", method: .put, params: server)
     }
     
-    /// Updates the attributes of a server.
+    /// Updates the attributes of an inbox (server).
     ///
     ///  - Parameters:
-    ///    - id: The unique identifier of the server.
-    ///    - server: The updated server.
+    ///    - id: The unique identifier of the inbox (server).
+    ///    - server: The updated inbox (server).
     ///  - Returns: The updated ``Server``.
     public func update(id: String, server: Server) async throws -> Server {
         let result = await self.updateResult(id: id, server: server)
@@ -112,20 +112,20 @@ public class Servers {
         }
     }
     
-    /// Permanently delete a server. This will also delete all messages, associated attachments, etc. within the server. This operation cannot be undone.
+    /// Permanently delete an inbox (server). This will also delete all messages, associated attachments, etc. within the inbox (server). This operation cannot be undone.
     ///
-    ///  - Parameter id: The unique identifier of the server.
-    ///  - Returns: A `Result` that is successful once the server has been deleted, or an `Error` on failure.
+    ///  - Parameter id: The unique identifier of the inbox (server).
+    ///  - Returns: A `Result` that is successful once the inbox (server) has been deleted, or an `Error` on failure.
     public func deleteResult(id: String) async -> Result<(), Error> {
         guard let client = self.client else { return .failure(MailosaurError.clientUninitialized) }
         let result: Result<MailosaurClient.None, Error> = await client.performRequest(path: "api/servers/\(id)", method: .delete)
         return result.map { _ in () }
     }
     
-    /// Permanently delete a server. This will also delete all messages, associated attachments, etc. within the server. This operation cannot be undone.
+    /// Permanently delete an inbox (server). This will also delete all messages, associated attachments, etc. within the inbox (server). This operation cannot be undone.
     ///
-    ///  - Parameter id: The unique identifier of the server.
-    ///  - Returns: Once the server has been deleted.
+    ///  - Parameter id: The unique identifier of the inbox (server).
+    ///  - Returns: Once the inbox (server) has been deleted.
     public func delete(id: String) async throws {
         let result = await self.deleteResult(id: id)
         switch result {
@@ -136,10 +136,10 @@ public class Servers {
         }
     }
     
-    /// Generates a random email address by appending a random string in front of the server's domain name.
+    /// Generates a random email address by appending a random string in front of the domain name of the inbox (server).
     ///
-    ///  - Parameter serverId: The identifier of the server.
-    ///  - Returns: A random email address ending in the server's domain.
+    ///  - Parameter serverId: The identifier of the inbox (server).
+    ///  - Returns: A random email address ending in the domain of the inbox (server).
     public static func generateEmailAddress(serverId: String) -> String {
         let host = ProcessInfo.processInfo.environment["MAILOSAUR_SMTP_HOST"] ?? "mailosaur.net"
         let uuid = UUID().uuidString.lowercased()

--- a/Sources/Mailosaur/Operations/Servers.swift
+++ b/Sources/Mailosaur/Operations/Servers.swift
@@ -7,6 +7,9 @@
 
 import Foundation
 
+/// Operations for creating and managing your Mailosaur servers — the virtual inboxes that
+/// group your tests together, each with its own domain and SMTP/POP3/IMAP credentials.
+/// Accessed via `client.servers`.
 public class Servers {
     // Must be weak to prevent a retain cycle
     private weak var client: MailosaurClient?
@@ -16,12 +19,16 @@ public class Servers {
     }
     
     /// Returns a list of your virtual servers. Servers are returned sorted in alphabetical order.
+    ///
+    /// - Returns: A `Result` containing a ``ServerListResult`` of your servers on success, or an `Error` on failure.
     public func listResult() async -> Result<ServerListResult, Error> {
         guard let client = self.client else { return .failure(MailosaurError.clientUninitialized) }
         return await client.performRequest(path: "api/servers")
     }
     
     /// Returns a list of your virtual servers. Servers are returned sorted in alphabetical order.
+    ///
+    /// - Returns: A ``ServerListResult`` containing your servers.
     public func list() async throws -> ServerListResult {
         let result = await self.listResult()
         switch result {
@@ -35,6 +42,7 @@ public class Servers {
     /// Creates a new virtual server.
     ///
     ///  - Parameter options: Options used to create a new Mailosaur server.
+    ///  - Returns: A `Result` containing the newly-created ``Server`` on success, or an `Error` on failure.
     public func createResult(options: ServerCreateOptions) async -> Result<Server, Error> {
         guard let client = self.client else { return .failure(MailosaurError.clientUninitialized) }
         return await client.performRequest(path: "api/servers", method: .post, params: options)
@@ -43,6 +51,7 @@ public class Servers {
     /// Creates a new virtual server.
     ///
     ///  - Parameter options: Options used to create a new Mailosaur server.
+    ///  - Returns: The newly-created ``Server``.
     public func create(options: ServerCreateOptions) async throws -> Server {
         let result = await self.createResult(options: options)
         switch result {
@@ -56,6 +65,7 @@ public class Servers {
     /// Retrieves the detail for a single server.
     ///
     ///  - Parameter id: The unique identifier of the server.
+    ///  - Returns: A `Result` containing the ``Server`` on success, or an `Error` on failure.
     public func getResult(id: String) async -> Result<Server, Error> {
         guard let client = self.client else { return .failure(MailosaurError.clientUninitialized) }
         return await client.performRequest(path: "api/servers/\(id)")
@@ -64,6 +74,7 @@ public class Servers {
     /// Retrieves the detail for a single server.
     ///
     ///  - Parameter id: The unique identifier of the server.
+    ///  - Returns: The ``Server``.
     public func get(id: String) async throws -> Server {
         let result = await self.getResult(id: id)
         switch result {
@@ -76,8 +87,10 @@ public class Servers {
     
     /// Updates the attributes of a server.
     ///
-    ///  - Parameter id: The unique identifier of the server.
-    ///  - Parameter server: The updated server.
+    ///  - Parameters:
+    ///    - id: The unique identifier of the server.
+    ///    - server: The updated server.
+    ///  - Returns: A `Result` containing the updated ``Server`` on success, or an `Error` on failure.
     public func updateResult(id: String, server: Server) async -> Result<Server, Error> {
         guard let client = self.client else { return .failure(MailosaurError.clientUninitialized) }
         return await client.performRequest(path: "api/servers/\(id)", method: .put, params: server)
@@ -85,8 +98,10 @@ public class Servers {
     
     /// Updates the attributes of a server.
     ///
-    ///  - Parameter id: The unique identifier of the server.
-    ///  - Parameter server: The updated server.
+    ///  - Parameters:
+    ///    - id: The unique identifier of the server.
+    ///    - server: The updated server.
+    ///  - Returns: The updated ``Server``.
     public func update(id: String, server: Server) async throws -> Server {
         let result = await self.updateResult(id: id, server: server)
         switch result {
@@ -100,6 +115,7 @@ public class Servers {
     /// Permanently delete a server. This will also delete all messages, associated attachments, etc. within the server. This operation cannot be undone.
     ///
     ///  - Parameter id: The unique identifier of the server.
+    ///  - Returns: A `Result` that is successful once the server has been deleted, or an `Error` on failure.
     public func deleteResult(id: String) async -> Result<(), Error> {
         guard let client = self.client else { return .failure(MailosaurError.clientUninitialized) }
         let result: Result<MailosaurClient.None, Error> = await client.performRequest(path: "api/servers/\(id)", method: .delete)
@@ -109,6 +125,7 @@ public class Servers {
     /// Permanently delete a server. This will also delete all messages, associated attachments, etc. within the server. This operation cannot be undone.
     ///
     ///  - Parameter id: The unique identifier of the server.
+    ///  - Returns: Once the server has been deleted.
     public func delete(id: String) async throws {
         let result = await self.deleteResult(id: id)
         switch result {
@@ -122,6 +139,7 @@ public class Servers {
     /// Generates a random email address by appending a random string in front of the server's domain name.
     ///
     ///  - Parameter serverId: The identifier of the server.
+    ///  - Returns: A random email address ending in the server's domain.
     public static func generateEmailAddress(serverId: String) -> String {
         let host = ProcessInfo.processInfo.environment["MAILOSAUR_SMTP_HOST"] ?? "mailosaur.net"
         let uuid = UUID().uuidString.lowercased()

--- a/Sources/Mailosaur/Operations/Usage.swift
+++ b/Sources/Mailosaur/Operations/Usage.swift
@@ -5,21 +5,27 @@
 //  Created by Mailosaur on 20.01.2023.
 //
 
+/// Operations for inspecting your account's usage limits and recent transactional usage.
+/// These endpoints require authentication with an account-level API key. Accessed via `client.usage`.
 public class Usage {
     // Must be weak to prevent a retain cycle
     private weak var client: MailosaurClient?
-    
+
     public init(client: MailosaurClient) {
         self.client = client
     }
-    
+
     /// Retrieve account usage limits. Details the current limits and usage for your account. This endpoint requires authentication with an account-level API key.
+    ///
+    /// - Returns: A `Result` containing the ``UsageAccountLimits`` for your account on success, or an `Error` on failure.
     public func limitsResult() async -> Result<UsageAccountLimits, Error> {
         guard let client = self.client else { return .failure(MailosaurError.clientUninitialized) }
         return await client.performRequest(path: "api/usage/limits")
     }
     
     /// Retrieve account usage limits. Details the current limits and usage for your account. This endpoint requires authentication with an account-level API key.
+    ///
+    /// - Returns: The ``UsageAccountLimits`` for your account.
     public func limits() async throws -> UsageAccountLimits {
         let result = await self.limitsResult()
         switch result {
@@ -31,12 +37,16 @@ public class Usage {
     }
     
     /// Retrieves the last 31 days of transactional usage. This endpoint requires authentication with an account-level API key.
+    ///
+    /// - Returns: A `Result` containing a ``UsageTransactionListResult`` for the last 31 days on success, or an `Error` on failure.
     public func transactionsResult() async -> Result<UsageTransactionListResult, Error> {
         guard let client = self.client else { return .failure(MailosaurError.clientUninitialized) }
         return await client.performRequest(path: "api/usage/transactions")
     }
     
     /// Retrieves the last 31 days of transactional usage. This endpoint requires authentication with an account-level API key.
+    ///
+    /// - Returns: A ``UsageTransactionListResult`` for the last 31 days.
     public func transactions() async throws -> UsageTransactionListResult {
         let result = await self.transactionsResult()
         switch result {


### PR DESCRIPTION
## Summary

- Add and expand Intellisense doc comments across the client and operations classes (descriptions, parameters, and return values).
- Adopt **inbox (server)** terminology in the doc-comment prose, so hover documentation matches the dashboard UI.

## Scope

- Doc comments only — no code, public API, or behaviour changes.
- Parameter names, type names, and other code identifiers are unchanged.
